### PR TITLE
Simplify logger calls

### DIFF
--- a/apiHTTPChannel.go
+++ b/apiHTTPChannel.go
@@ -7,26 +7,25 @@ import (
 
 //HTTPAPIServerStreamChannelCodec function return codec info struct
 func HTTPAPIServerStreamChannelCodec(c *gin.Context) {
+	requestLogger := log.WithFields(logrus.Fields{
+		"module":  "http_stream",
+		"stream":  c.Param("uuid"),
+		"channel": c.Param("channel"),
+		"func":    "HTTPAPIServerStreamChannelCodec",
+	})
+
 	if !Storage.StreamChannelExist(c.Param("uuid"), c.Param("channel")) {
 		c.IndentedJSON(500, Message{Status: 0, Payload: ErrorStreamNotFound.Error()})
-		log.WithFields(logrus.Fields{
-			"module":  "http_stream",
-			"stream":  c.Param("uuid"),
-			"channel": c.Param("channel"),
-			"func":    "HTTPAPIServerStreamChannelCodec",
-			"call":    "StreamChannelExist",
+		requestLogger.WithFields(logrus.Fields{
+			"call": "StreamChannelExist",
 		}).Errorln(ErrorStreamNotFound.Error())
 		return
 	}
 	codecs, err := Storage.StreamChannelCodecs(c.Param("uuid"), c.Param("channel"))
 	if err != nil {
 		c.IndentedJSON(500, Message{Status: 0, Payload: err.Error()})
-		log.WithFields(logrus.Fields{
-			"module":  "http_stream",
-			"stream":  c.Param("uuid"),
-			"channel": c.Param("channel"),
-			"func":    "HTTPAPIServerStreamChannelCodec",
-			"call":    "StreamChannelCodec",
+		requestLogger.WithFields(logrus.Fields{
+			"call": "StreamChannelCodec",
 		}).Errorln(err.Error())
 		return
 	}
@@ -69,28 +68,27 @@ func HTTPAPIServerStreamChannelReload(c *gin.Context) {
 
 //HTTPAPIServerStreamChannelEdit function edit stream
 func HTTPAPIServerStreamChannelEdit(c *gin.Context) {
+	requestLogger := log.WithFields(logrus.Fields{
+		"module":  "http_stream",
+		"stream":  c.Param("uuid"),
+		"channel": c.Param("channel"),
+		"func":    "HTTPAPIServerStreamChannelEdit",
+	})
+
 	var payload ChannelST
 	err := c.BindJSON(&payload)
 	if err != nil {
 		c.IndentedJSON(400, Message{Status: 0, Payload: err.Error()})
-		log.WithFields(logrus.Fields{
-			"module":  "http_stream",
-			"stream":  c.Param("uuid"),
-			"channel": c.Param("channel"),
-			"func":    "HTTPAPIServerStreamEdit",
-			"call":    "BindJSON",
+		requestLogger.WithFields(logrus.Fields{
+			"call": "BindJSON",
 		}).Errorln(err.Error())
 		return
 	}
 	err = Storage.StreamChannelEdit(c.Param("uuid"), c.Param("channel"), payload)
 	if err != nil {
 		c.IndentedJSON(500, Message{Status: 0, Payload: err.Error()})
-		log.WithFields(logrus.Fields{
-			"module":  "http_stream",
-			"stream":  c.Param("uuid"),
-			"channel": c.Param("channel"),
-			"func":    "HTTPAPIServerStreamChannelEdit",
-			"call":    "StreamChannelEdit",
+		requestLogger.WithFields(logrus.Fields{
+			"call": "StreamChannelEdit",
 		}).Errorln(err.Error())
 		return
 	}
@@ -99,15 +97,18 @@ func HTTPAPIServerStreamChannelEdit(c *gin.Context) {
 
 //HTTPAPIServerStreamChannelDelete function delete stream
 func HTTPAPIServerStreamChannelDelete(c *gin.Context) {
+	requestLogger := log.WithFields(logrus.Fields{
+		"module":  "http_stream",
+		"stream":  c.Param("uuid"),
+		"channel": c.Param("channel"),
+		"func":    "HTTPAPIServerStreamChannelDelete",
+	})
+
 	err := Storage.StreamChannelDelete(c.Param("uuid"), c.Param("channel"))
 	if err != nil {
 		c.IndentedJSON(500, Message{Status: 0, Payload: err.Error()})
-		log.WithFields(logrus.Fields{
-			"module":  "http_stream",
-			"stream":  c.Param("uuid"),
-			"channel": c.Param("channel"),
-			"func":    "HTTPAPIServerStreamChannelDelete",
-			"call":    "StreamChannelDelete",
+		requestLogger.WithFields(logrus.Fields{
+			"call": "StreamChannelDelete",
 		}).Errorln(err.Error())
 		return
 	}
@@ -116,28 +117,27 @@ func HTTPAPIServerStreamChannelDelete(c *gin.Context) {
 
 //HTTPAPIServerStreamChannelAdd function add new stream
 func HTTPAPIServerStreamChannelAdd(c *gin.Context) {
+	requestLogger := log.WithFields(logrus.Fields{
+		"module":  "http_stream",
+		"stream":  c.Param("uuid"),
+		"channel": c.Param("channel"),
+		"func":    "HTTPAPIServerStreamChannelAdd",
+	})
+
 	var payload ChannelST
 	err := c.BindJSON(&payload)
 	if err != nil {
 		c.IndentedJSON(400, Message{Status: 0, Payload: err.Error()})
-		log.WithFields(logrus.Fields{
-			"module":  "http_stream",
-			"stream":  c.Param("uuid"),
-			"channel": c.Param("channel"),
-			"func":    "HTTPAPIServerStreamChannelAdd",
-			"call":    "BindJSON",
+		requestLogger.WithFields(logrus.Fields{
+			"call": "BindJSON",
 		}).Errorln(err.Error())
 		return
 	}
 	err = Storage.StreamChannelAdd(c.Param("uuid"), c.Param("channel"), payload)
 	if err != nil {
 		c.IndentedJSON(500, Message{Status: 0, Payload: err.Error()})
-		log.WithFields(logrus.Fields{
-			"module":  "http_stream",
-			"stream":  c.Param("uuid"),
-			"channel": c.Param("channel"),
-			"func":    "HTTPAPIServerStreamChannelAdd",
-			"call":    "StreamChannelAdd",
+		requestLogger.WithFields(logrus.Fields{
+			"call": "StreamChannelAdd",
 		}).Errorln(err.Error())
 		return
 	}

--- a/apiHTTPHLSLL.go
+++ b/apiHTTPHLSLL.go
@@ -9,14 +9,17 @@ import (
 
 //HTTPAPIServerStreamHLSLLInit send client ts segment
 func HTTPAPIServerStreamHLSLLInit(c *gin.Context) {
+	requestLogger := log.WithFields(logrus.Fields{
+		"module":  "http_hlsll",
+		"stream":  c.Param("uuid"),
+		"channel": c.Param("channel"),
+		"func":    "HTTPAPIServerStreamHLSLLInit",
+	})
+
 	if !Storage.StreamChannelExist(c.Param("uuid"), c.Param("channel")) {
 		c.IndentedJSON(500, Message{Status: 0, Payload: ErrorStreamNotFound.Error()})
-		log.WithFields(logrus.Fields{
-			"module":  "http_hlsll",
-			"stream":  c.Param("uuid"),
-			"channel": c.Param("channel"),
-			"func":    "HTTPAPIServerStreamHLSLLInit",
-			"call":    "StreamChannelExist",
+		requestLogger.WithFields(logrus.Fields{
+			"call": "StreamChannelExist",
 		}).Errorln(ErrorStreamNotFound.Error())
 		return
 	}
@@ -25,12 +28,8 @@ func HTTPAPIServerStreamHLSLLInit(c *gin.Context) {
 	codecs, err := Storage.StreamChannelCodecs(c.Param("uuid"), c.Param("channel"))
 	if err != nil {
 		c.IndentedJSON(500, Message{Status: 0, Payload: err.Error()})
-		log.WithFields(logrus.Fields{
-			"module":  "http_hlsll",
-			"stream":  c.Param("uuid"),
-			"channel": c.Param("channel"),
-			"func":    "HTTPAPIServerStreamHLSLLInit",
-			"call":    "StreamChannelCodecs",
+		requestLogger.WithFields(logrus.Fields{
+			"call": "StreamChannelCodecs",
 		}).Errorln(err.Error())
 		return
 	}
@@ -38,12 +37,8 @@ func HTTPAPIServerStreamHLSLLInit(c *gin.Context) {
 	err = Muxer.WriteHeader(codecs)
 	if err != nil {
 		c.IndentedJSON(500, Message{Status: 0, Payload: err.Error()})
-		log.WithFields(logrus.Fields{
-			"module":  "http_hlsll",
-			"stream":  c.Param("uuid"),
-			"channel": c.Param("channel"),
-			"func":    "HTTPAPIServerStreamHLSLLInit",
-			"call":    "WriteHeader",
+		requestLogger.WithFields(logrus.Fields{
+			"call": "WriteHeader",
 		}).Errorln(err.Error())
 		return
 	}
@@ -52,28 +47,26 @@ func HTTPAPIServerStreamHLSLLInit(c *gin.Context) {
 	_, err = c.Writer.Write(buf)
 	if err != nil {
 		c.IndentedJSON(500, Message{Status: 0, Payload: err.Error()})
-		log.WithFields(logrus.Fields{
-			"module":  "http_hlsll",
-			"stream":  c.Param("uuid"),
-			"channel": c.Param("channel"),
-			"func":    "HTTPAPIServerStreamHLSLLInit",
-			"call":    "Write",
+		requestLogger.WithFields(logrus.Fields{
+			"call": "Write",
 		}).Errorln(err.Error())
 		return
 	}
-
 }
 
 //HTTPAPIServerStreamHLSLLM3U8 send client m3u8 play list
 func HTTPAPIServerStreamHLSLLM3U8(c *gin.Context) {
+	requestLogger := log.WithFields(logrus.Fields{
+		"module":  "http_hlsll",
+		"stream":  c.Param("uuid"),
+		"channel": c.Param("channel"),
+		"func":    "HTTPAPIServerStreamHLSLLM3U8",
+	})
+
 	if !Storage.StreamChannelExist(c.Param("uuid"), c.Param("channel")) {
 		c.IndentedJSON(500, Message{Status: 0, Payload: ErrorStreamNotFound.Error()})
-		log.WithFields(logrus.Fields{
-			"module":  "http_hlsll",
-			"stream":  c.Param("uuid"),
-			"channel": c.Param("channel"),
-			"func":    "HTTPAPIServerStreamHLSLLM3U8",
-			"call":    "StreamChannelExist",
+		requestLogger.WithFields(logrus.Fields{
+			"call": "StreamChannelExist",
 		}).Errorln(ErrorStreamNotFound.Error())
 		return
 	}
@@ -81,23 +74,15 @@ func HTTPAPIServerStreamHLSLLM3U8(c *gin.Context) {
 	Storage.StreamChannelRun(c.Param("uuid"), c.Param("channel"))
 	index, err := Storage.HLSMuxerM3U8(c.Param("uuid"), c.Param("channel"), stringToInt(c.DefaultQuery("_HLS_msn", "-1")), stringToInt(c.DefaultQuery("_HLS_part", "-1")))
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"module":  "http_hlsll",
-			"stream":  c.Param("uuid"),
-			"channel": c.Param("channel"),
-			"func":    "HTTPAPIServerStreamHLSLLM3U8",
-			"call":    "HLSMuxerM3U8",
+		requestLogger.WithFields(logrus.Fields{
+			"call": "HLSMuxerM3U8",
 		}).Errorln(ErrorStreamNotFound.Error())
 		return
 	}
 	_, err = c.Writer.Write([]byte(index))
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"module":  "http_hlsll",
-			"stream":  c.Param("uuid"),
-			"channel": c.Param("channel"),
-			"func":    "HTTPAPIServerStreamHLSLLM3U8",
-			"call":    "Write",
+		requestLogger.WithFields(logrus.Fields{
+			"call": "Write",
 		}).Errorln(ErrorStreamNotFound.Error())
 		return
 	}
@@ -105,72 +90,55 @@ func HTTPAPIServerStreamHLSLLM3U8(c *gin.Context) {
 
 //HTTPAPIServerStreamHLSLLM4Segment send client ts segment
 func HTTPAPIServerStreamHLSLLM4Segment(c *gin.Context) {
+	requestLogger := log.WithFields(logrus.Fields{
+		"module":  "http_hlsll",
+		"stream":  c.Param("uuid"),
+		"channel": c.Param("channel"),
+		"func":    "HTTPAPIServerStreamHLSLLM4Segment",
+	})
+
 	c.Header("Content-Type", "video/mp4")
 	if !Storage.StreamChannelExist(c.Param("uuid"), c.Param("channel")) {
 		c.IndentedJSON(500, Message{Status: 0, Payload: ErrorStreamNotFound.Error()})
-		log.WithFields(logrus.Fields{
-			"module":  "http_hlsll",
-			"stream":  c.Param("uuid"),
-			"channel": c.Param("channel"),
-			"func":    "HTTPAPIServerStreamHLSLLM4Segment",
-			"call":    "StreamChannelExist",
+		requestLogger.WithFields(logrus.Fields{
+			"call": "StreamChannelExist",
 		}).Errorln(ErrorStreamNotFound.Error())
 		return
 	}
 	codecs, err := Storage.StreamChannelCodecs(c.Param("uuid"), c.Param("channel"))
 	if err != nil {
 		c.IndentedJSON(500, Message{Status: 0, Payload: err.Error()})
-		log.WithFields(logrus.Fields{
-			"module":  "http_hlsll",
-			"stream":  c.Param("uuid"),
-			"channel": c.Param("channel"),
-			"func":    "HTTPAPIServerStreamHLSLLM4Segment",
-			"call":    "StreamChannelCodecs",
+		requestLogger.WithFields(logrus.Fields{
+			"call": "StreamChannelCodecs",
 		}).Errorln(err.Error())
 		return
 	}
 	if codecs == nil {
-		log.WithFields(logrus.Fields{
-			"module":  "http_hlsll",
-			"stream":  c.Param("uuid"),
-			"channel": c.Param("channel"),
-			"func":    "HTTPAPIServerStreamHLSLLM4Segment",
-			"call":    "StreamCodecs",
+		requestLogger.WithFields(logrus.Fields{
+			"call": "StreamCodecs",
 		}).Errorln("Codec Null")
 		return
 	}
 	Muxer := mp4f.NewMuxer(nil)
 	err = Muxer.WriteHeader(codecs)
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"module":  "http_hlsll",
-			"stream":  c.Param("uuid"),
-			"channel": c.Param("channel"),
-			"func":    "HTTPAPIServerStreamHLSLLM4Segment",
-			"call":    "WriteHeader",
+		requestLogger.WithFields(logrus.Fields{
+			"call": "WriteHeader",
 		}).Errorln(err.Error())
 		return
 	}
 	seqData, err := Storage.HLSMuxerSegment(c.Param("uuid"), c.Param("channel"), stringToInt(c.Param("segment")))
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"module":  "http_hlsll",
-			"stream":  c.Param("uuid"),
-			"channel": c.Param("channel"),
-			"func":    "HTTPAPIServerStreamHLSLLM4Segment",
-			"call":    "HLSMuxerSegment",
+		requestLogger.WithFields(logrus.Fields{
+			"call": "HLSMuxerSegment",
 		}).Errorln(err.Error())
 		return
 	}
 	for _, v := range seqData {
 		err = Muxer.WritePacket4(*v)
 		if err != nil {
-			log.WithFields(logrus.Fields{
-				"module":  "http_hlsll",
-				"stream":  c.Param("uuid"),
-				"channel": c.Param("channel"),
-				"func":    "HTTPAPIServerStreamHLSLLM4Segment",
-				"call":    "WritePacket4",
+			requestLogger.WithFields(logrus.Fields{
+				"call": "WritePacket4",
 			}).Errorln(err.Error())
 			return
 		}
@@ -178,12 +146,8 @@ func HTTPAPIServerStreamHLSLLM4Segment(c *gin.Context) {
 	buf := Muxer.Finalize()
 	_, err = c.Writer.Write(buf)
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"module":  "http_hlsll",
-			"stream":  c.Param("uuid"),
-			"channel": c.Param("channel"),
-			"func":    "HTTPAPIServerStreamHLSLLM4Segment",
-			"call":    "Write",
+		requestLogger.WithFields(logrus.Fields{
+			"call": "Write",
 		}).Errorln(err.Error())
 		return
 	}
@@ -191,72 +155,55 @@ func HTTPAPIServerStreamHLSLLM4Segment(c *gin.Context) {
 
 //HTTPAPIServerStreamHLSLLM4Fragment send client ts segment
 func HTTPAPIServerStreamHLSLLM4Fragment(c *gin.Context) {
+	requestLogger := log.WithFields(logrus.Fields{
+		"module":  "http_hlsll",
+		"stream":  c.Param("uuid"),
+		"channel": c.Param("channel"),
+		"func":    "HTTPAPIServerStreamHLSLLM4Fragment",
+	})
+
 	c.Header("Content-Type", "video/mp4")
 	if !Storage.StreamChannelExist(c.Param("uuid"), c.Param("channel")) {
 		c.IndentedJSON(500, Message{Status: 0, Payload: ErrorStreamNotFound.Error()})
-		log.WithFields(logrus.Fields{
-			"module":  "http_hlsll",
-			"stream":  c.Param("uuid"),
-			"channel": c.Param("channel"),
-			"func":    "HTTPAPIServerStreamHLSLLM4Fragment",
-			"call":    "StreamChannelExist",
+		requestLogger.WithFields(logrus.Fields{
+			"call": "StreamChannelExist",
 		}).Errorln(ErrorStreamNotFound.Error())
 		return
 	}
 	codecs, err := Storage.StreamChannelCodecs(c.Param("uuid"), c.Param("channel"))
 	if err != nil {
 		c.IndentedJSON(500, Message{Status: 0, Payload: err.Error()})
-		log.WithFields(logrus.Fields{
-			"module":  "http_hlsll",
-			"stream":  c.Param("uuid"),
-			"channel": c.Param("channel"),
-			"func":    "HTTPAPIServerStreamHLSLLM4Fragment",
-			"call":    "StreamChannelCodecs",
+		requestLogger.WithFields(logrus.Fields{
+			"call": "StreamChannelCodecs",
 		}).Errorln(err.Error())
 		return
 	}
 	if codecs == nil {
-		log.WithFields(logrus.Fields{
-			"module":  "http_hlsll",
-			"stream":  c.Param("uuid"),
-			"channel": c.Param("channel"),
-			"func":    "HTTPAPIServerStreamHLSLLM4Fragment",
-			"call":    "StreamCodecs",
+		requestLogger.WithFields(logrus.Fields{
+			"call": "StreamCodecs",
 		}).Errorln("Codec Null")
 		return
 	}
 	Muxer := mp4f.NewMuxer(nil)
 	err = Muxer.WriteHeader(codecs)
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"module":  "http_hlsll",
-			"stream":  c.Param("uuid"),
-			"channel": c.Param("channel"),
-			"func":    "HTTPAPIServerStreamHLSLLM4Fragment",
-			"call":    "WriteHeader",
+		requestLogger.WithFields(logrus.Fields{
+			"call": "WriteHeader",
 		}).Errorln(err.Error())
 		return
 	}
 	seqData, err := Storage.HLSMuxerFragment(c.Param("uuid"), c.Param("channel"), stringToInt(c.Param("segment")), stringToInt(c.Param("fragment")))
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"module":  "http_hlsll",
-			"stream":  c.Param("uuid"),
-			"channel": c.Param("channel"),
-			"func":    "HTTPAPIServerStreamHLSLLM4Fragment",
-			"call":    "HLSMuxerFragment",
+		requestLogger.WithFields(logrus.Fields{
+			"call": "HLSMuxerFragment",
 		}).Errorln(err.Error())
 		return
 	}
 	for _, v := range seqData {
 		err = Muxer.WritePacket4(*v)
 		if err != nil {
-			log.WithFields(logrus.Fields{
-				"module":  "http_hlsll",
-				"stream":  c.Param("uuid"),
-				"channel": c.Param("channel"),
-				"func":    "HTTPAPIServerStreamHLSLLM4Fragment",
-				"call":    "WritePacket4",
+			requestLogger.WithFields(logrus.Fields{
+				"call": "WritePacket4",
 			}).Errorln(err.Error())
 			return
 		}
@@ -264,12 +211,8 @@ func HTTPAPIServerStreamHLSLLM4Fragment(c *gin.Context) {
 	buf := Muxer.Finalize()
 	_, err = c.Writer.Write(buf)
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			"module":  "http_hlsll",
-			"stream":  c.Param("uuid"),
-			"channel": c.Param("channel"),
-			"func":    "HTTPAPIServerStreamHLSLLM4Fragment",
-			"call":    "Write",
+		requestLogger.WithFields(logrus.Fields{
+			"call": "Write",
 		}).Errorln(err.Error())
 		return
 	}

--- a/apiHTTPStream.go
+++ b/apiHTTPStream.go
@@ -12,23 +12,24 @@ func HTTPAPIServerStreams(c *gin.Context) {
 
 //HTTPAPIServerStreamsMultiControlAdd function add new stream's
 func HTTPAPIServerStreamsMultiControlAdd(c *gin.Context) {
+	requestLogger := log.WithFields(logrus.Fields{
+		"module": "http_stream",
+		"func":   "HTTPAPIServerStreamsMultiControlAdd",
+	})
+
 	var payload StorageST
 	err := c.BindJSON(&payload)
 	if err != nil {
 		c.IndentedJSON(400, Message{Status: 0, Payload: err.Error()})
-		log.WithFields(logrus.Fields{
-			"module": "http_stream",
-			"func":   "HTTPAPIServerStreamsMultiControlAdd",
-			"call":   "BindJSON",
+		requestLogger.WithFields(logrus.Fields{
+			"call": "BindJSON",
 		}).Errorln(err.Error())
 		return
 	}
 	if payload.Streams == nil || len(payload.Streams) < 1 {
 		c.IndentedJSON(400, Message{Status: 0, Payload: ErrorStreamsLen0.Error()})
-		log.WithFields(logrus.Fields{
-			"module": "http_stream",
-			"func":   "HTTPAPIServerStreamsMultiControlAdd",
-			"call":   "len(payload)",
+		requestLogger.WithFields(logrus.Fields{
+			"call": "len(payload)",
 		}).Errorln(ErrorStreamsLen0.Error())
 		return
 	}
@@ -37,10 +38,8 @@ func HTTPAPIServerStreamsMultiControlAdd(c *gin.Context) {
 	for k, v := range payload.Streams {
 		err = Storage.StreamAdd(k, v)
 		if err != nil {
-			log.WithFields(logrus.Fields{
-				"module": "http_stream",
+			requestLogger.WithFields(logrus.Fields{
 				"stream": k,
-				"func":   "HTTPAPIServerStreamsMultiControlAdd",
 				"call":   "StreamAdd",
 			}).Errorln(err.Error())
 			resp[k] = Message{Status: 0, Payload: err.Error()}
@@ -58,23 +57,24 @@ func HTTPAPIServerStreamsMultiControlAdd(c *gin.Context) {
 
 //HTTPAPIServerStreamsMultiControlDelete function delete stream's
 func HTTPAPIServerStreamsMultiControlDelete(c *gin.Context) {
+	requestLogger := log.WithFields(logrus.Fields{
+		"module": "http_stream",
+		"func":   "HTTPAPIServerStreamsMultiControlDelete",
+	})
+
 	var payload []string
 	err := c.BindJSON(&payload)
 	if err != nil {
 		c.IndentedJSON(400, Message{Status: 0, Payload: err.Error()})
-		log.WithFields(logrus.Fields{
-			"module": "http_stream",
-			"func":   "HTTPAPIServerStreamsMultiControlDelete",
-			"call":   "BindJSON",
+		requestLogger.WithFields(logrus.Fields{
+			"call": "BindJSON",
 		}).Errorln(err.Error())
 		return
 	}
 	if len(payload) < 1 {
 		c.IndentedJSON(400, Message{Status: 0, Payload: ErrorStreamsLen0.Error()})
-		log.WithFields(logrus.Fields{
-			"module": "http_stream",
-			"func":   "HTTPAPIServerStreamsMultiControlDelete",
-			"call":   "len(payload)",
+		requestLogger.WithFields(logrus.Fields{
+			"call": "len(payload)",
 		}).Errorln(ErrorStreamsLen0.Error())
 		return
 	}
@@ -83,10 +83,8 @@ func HTTPAPIServerStreamsMultiControlDelete(c *gin.Context) {
 	for _, key := range payload {
 		err := Storage.StreamDelete(key)
 		if err != nil {
-			log.WithFields(logrus.Fields{
-				"module": "http_stream",
+			requestLogger.WithFields(logrus.Fields{
 				"stream": key,
-				"func":   "HTTPAPIServerStreamsMultiControlDelete",
 				"call":   "StreamDelete",
 			}).Errorln(err.Error())
 			resp[key] = Message{Status: 0, Payload: err.Error()}

--- a/streamCore.go
+++ b/streamCore.go
@@ -19,52 +19,37 @@ func StreamServerRunStreamDo(streamID string, channelID string) {
 		}
 	}()
 	for {
-		log.WithFields(logrus.Fields{
+		baseLogger := log.WithFields(logrus.Fields{
 			"module":  "core",
 			"stream":  streamID,
 			"channel": channelID,
 			"func":    "StreamServerRunStreamDo",
-			"call":    "Run",
-		}).Infoln("Run stream")
+		})
+
+		baseLogger.WithFields(logrus.Fields{"call": "Run"}).Infoln("Run stream")
 		opt, err := Storage.StreamChannelControl(streamID, channelID)
 		if err != nil {
-			log.WithFields(logrus.Fields{
-				"module":  "core",
-				"stream":  streamID,
-				"channel": channelID,
-				"func":    "StreamChannelControl",
-				"call":    "Exit",
+			baseLogger.WithFields(logrus.Fields{
+				"call": "StreamChannelControl",
 			}).Infoln("Exit", err)
 			return
 		}
 		if opt.OnDemand && !Storage.ClientHas(streamID, channelID) {
-			log.WithFields(logrus.Fields{
-				"module":  "core",
-				"stream":  streamID,
-				"channel": channelID,
-				"func":    "StreamServerRunStreamDo",
-				"call":    "ClientHas",
+			baseLogger.WithFields(logrus.Fields{
+				"call": "ClientHas",
 			}).Infoln("Stop stream no client")
 			return
 		}
 		status, err = StreamServerRunStream(streamID, channelID, opt)
 		if status > 0 {
-			log.WithFields(logrus.Fields{
-				"module":  "core",
-				"stream":  streamID,
-				"channel": channelID,
-				"func":    "StreamServerRunStreamDo",
-				"call":    "StreamServerRunStream",
+			baseLogger.WithFields(logrus.Fields{
+				"call": "StreamServerRunStream",
 			}).Infoln("Stream exit by signal or not client")
 			return
 		}
 		if err != nil {
 			log.WithFields(logrus.Fields{
-				"module":  "core",
-				"stream":  streamID,
-				"channel": channelID,
-				"func":    "StreamServerRunStreamDo",
-				"call":    "Restart",
+				"call": "Restart",
 			}).Errorln("Stream error restart stream", err)
 		}
 		time.Sleep(2 * time.Second)


### PR DESCRIPTION
Reduce logger call noise so more of the function logic can be viewed on screen. The logger object that's set up at the top of the function isn't always called however the performance hit of instantiating the object is negligible.

https://github.com/sirupsen/logrus#default-fields