### PR TITLE
Remove page routes when demo mode is off

### DIFF
--- a/apiHTTPRouter.go
+++ b/apiHTTPRouter.go
@@ -43,18 +43,20 @@ func HTTPAPIServer() {
 		Html template
 	*/
 
-	public.GET("/", HTTPAPIServerIndex)
-	public.GET("/pages/stream/list", HTTPAPIStreamList)
-	public.GET("/pages/stream/add", HTTPAPIAddStream)
-	public.GET("/pages/stream/edit/:uuid", HTTPAPIEditStream)
-	public.GET("/pages/player/hls/:uuid/:channel", HTTPAPIPlayHls)
-	public.GET("/pages/player/mse/:uuid/:channel", HTTPAPIPlayMse)
-	public.GET("/pages/player/webrtc/:uuid/:channel", HTTPAPIPlayWebrtc)
-	public.GET("/pages/multiview", HTTPAPIMultiview)
-	public.Any("/pages/multiview/full", HTTPAPIFullScreenMultiView)
-	public.GET("/pages/documentation", HTTPAPIServerDocumentation)
-	public.GET("/pages/login", HTTPAPIPageLogin)
-	public.GET("/pages/player/all/:uuid/:channel", HTTPAPIPlayAll)
+	if Storage.ServerHTTPDemo() {
+		public.GET("/", HTTPAPIServerIndex)
+		public.GET("/pages/stream/list", HTTPAPIStreamList)
+		public.GET("/pages/stream/add", HTTPAPIAddStream)
+		public.GET("/pages/stream/edit/:uuid", HTTPAPIEditStream)
+		public.GET("/pages/player/hls/:uuid/:channel", HTTPAPIPlayHls)
+		public.GET("/pages/player/mse/:uuid/:channel", HTTPAPIPlayMse)
+		public.GET("/pages/player/webrtc/:uuid/:channel", HTTPAPIPlayWebrtc)
+		public.GET("/pages/multiview", HTTPAPIMultiview)
+		public.Any("/pages/multiview/full", HTTPAPIFullScreenMultiView)
+		public.GET("/pages/documentation", HTTPAPIServerDocumentation)
+		public.GET("/pages/login", HTTPAPIPageLogin)
+		public.GET("/pages/player/all/:uuid/:channel", HTTPAPIPlayAll)
+	}
 
 	/*
 		Stream Control elements


### PR DESCRIPTION
Allow api-only mode. Pages were being shown without css and js assets.

![image](https://user-images.githubusercontent.com/88207951/127699491-d4366fdd-9b85-4156-b62d-9fb9481f785f.png)
