### PR TITLE
Make basic auth optional for private handler

### DIFF
--- a/apiHTTPRouter.go
+++ b/apiHTTPRouter.go
@@ -36,7 +36,10 @@ func HTTPAPIServer() {
 
 	public.Use(CrossOrigin())
 	//Add private login password protect methods
-	privat := public.Group("/", gin.BasicAuth(gin.Accounts{Storage.ServerHTTPLogin(): Storage.ServerHTTPPassword()}))
+	privat := public.Group("/")
+	if Storage.ServerHTTPLogin() != "" && Storage.ServerHTTPPassword() != "" {
+		privat.Use(gin.BasicAuth(gin.Accounts{Storage.ServerHTTPLogin(): Storage.ServerHTTPPassword()}))
+	}
 	public.LoadHTMLGlob(Storage.ServerHTTPDir() + "/templates/*")
 
 	/*


### PR DESCRIPTION
Make basic auth only enabled when explicitly configured, so that RTSPtoWeb can be used easier in environments that provide their own security e.g. network restrictions to disable broad access.  Basic auth is still enabled by default with the example configuration.

This was tested manually by first running the server with the default config (verifying basic auth is required), then with a modified config without the http basic auth parameters (verifying that it is not required).