### PR TITLE
Add documetation details for the WebRTC API

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -449,6 +449,14 @@ NOTE: Use `wss` for a secure connection.
 http://127.0.0.1:8083/stream/{STREAM_ID}/channel/{CHANNEL_ID}/webrtc
 ```
 
+#### Request
+
+The request is an HTTP `POST` with a parameter `data` that is a base64 encoded SDP offer (e.g. `v=0...`) from a WebRTC client.
+
+#### Response
+
+The response is a base64 encoded SDP Answer.
+
 ### RTSP
 
 `/{STREAM_ID}/{CHANNEL_ID}`


### PR DESCRIPTION
Add some detail about the format of the WebRTC API, the parameter names, and the bas64 encoding.
Issue #71