### PR TITLE
Add Dockerfile to build RTSPtoWeb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1
+
+FROM golang:1.18rc1-alpine3.15 AS builder
+
+RUN apk add git
+
+WORKDIR /go/src/app
+COPY . .
+
+ENV CGO_ENABLED=0
+RUN go get \
+    && go mod download \
+    && go build -a -o rtsp-to-web
+
+FROM alpine:3.15
+
+WORKDIR /app
+
+COPY --from=builder /go/src/app/rtsp-to-web /app/
+COPY --from=builder /go/src/app/web /app/web
+COPY --from=builder /go/src/app/config.json /app/
+
+ENV GO111MODULE="on"
+ENV GIN_MODE="release"
+
+CMD ["./rtsp-to-web"]


### PR DESCRIPTION
Issue #91

```
$ docker build -t rtsp-to-web:latest .
...
Successfully built 3060d6906593
Successfully tagged rtsp-to-web:latest
$ docker image ls rtsp-to-web:latest
REPOSITORY    TAG       IMAGE ID       CREATED              SIZE
rtsp-to-web   latest    3060d6906593   About a minute ago   40.7MB
```