### PR TITLE
Workflow to publish docker images

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,0 +1,41 @@
+name: Create and publish Docker image
+
+on:
+  release:
+    types: [created]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Docker Login
+        uses: docker/login-action@v1.13.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker Metadata action
+        id: meta
+        uses: docker/metadata-action@v3.6.2
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2.9.0
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Add a workflow to publish docker images to github registry.

Docker images are created automatically when a release is created. 

For an example release: https://github.com/allenporter/RTSPtoWeb/releases/tag/0.0.1
https://github.com/allenporter/RTSPtoWeb/actions/runs/1869173484

Example run commands
```
$ docker pull ghcr.io/allenporter/rtsptoweb:latest
$ docker run --network host ghcr.io/allenporter/rtsptoweb:latest
time="2022-02-19T15:17:53Z" level=info msg="Server CORE start" func=main module=main
time="2022-02-19T15:17:53Z" level=info msg="Server RTSP start" call=Start func=RTSPServer module=rtsp_server
time="2022-02-19T15:17:53Z" level=info msg="Server HTTP start" call=Start func=RTSPServer module=http_server
time="2022-02-19T15:17:53Z" level=info msg="Run stream" call=Run channel=0 func=StreamServerRunStreamDo module=core stream=demo
time="2022-02-19T15:17:53Z" level=info msg="Server start success a wait signals" func=main module=main
...
```
