### PR TITLE
Add a channel_defaults configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,10 @@ file.php need response json
         }
       }
     }
-  }
+  },
+  "channel_defaults": {
+    "on_demand": true,
+  },
 }
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/gin-gonic/gin v1.7.7
 	github.com/go-playground/validator/v10 v10.10.0 // indirect
 	github.com/hashicorp/go-version v1.3.0
+	github.com/imdario/mergo v0.3.12
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/liip/sheriff v0.11.1
 	github.com/mattn/go-isatty v0.0.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/hashicorp/go-version v0.0.0-20161031182605-e96d38404026/go.mod h1:flt
 github.com/hashicorp/go-version v1.3.0 h1:McDWVJIU/y+u1BRV06dPaLfLCaT7fUTJLp5r04x7iNw=
 github.com/hashicorp/go-version v1.3.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
+github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=

--- a/storageConfig.go
+++ b/storageConfig.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/hashicorp/go-version"
 
+	"github.com/imdario/mergo"
+
 	"github.com/liip/sheriff"
 
 	"github.com/sirupsen/logrus"
@@ -45,11 +47,21 @@ func NewStreamCore() *StorageST {
 	debug = tmp.Server.Debug
 	for i, i2 := range tmp.Streams {
 		for i3, i4 := range i2.Channels {
-			i4.clients = make(map[string]ClientST)
-			i4.ack = time.Now().Add(-255 * time.Hour)
-			i4.hlsSegmentBuffer = make(map[int]SegmentOld)
-			i4.signals = make(chan int, 100)
-			i2.Channels[i3] = i4
+			channel := tmp.ChannelDefaults
+			err = mergo.Merge(&channel, i4)
+			if err != nil {
+				log.WithFields(logrus.Fields{
+					"module": "config",
+					"func":   "NewStreamCore",
+					"call":   "Merge",
+				}).Errorln(err.Error())
+				os.Exit(1)
+			}
+			channel.clients = make(map[string]ClientST)
+			channel.ack = time.Now().Add(-255 * time.Hour)
+			channel.hlsSegmentBuffer = make(map[int]SegmentOld)
+			channel.signals = make(chan int, 100)
+			i2.Channels[i3] = channel
 		}
 		tmp.Streams[i] = i2
 	}

--- a/storageStreamChannel.go
+++ b/storageStreamChannel.go
@@ -4,20 +4,31 @@ import (
 	"time"
 
 	"github.com/deepch/vdk/av"
+	"github.com/imdario/mergo"
 	"github.com/sirupsen/logrus"
 )
 
 //StreamChannelMake check stream exist
 func (obj *StorageST) StreamChannelMake(val ChannelST) ChannelST {
+	channel := obj.ChannelDefaults
+	if err := mergo.Merge(&channel, val); err != nil {
+		// Just ignore the default values and continue
+		channel = val
+		log.WithFields(logrus.Fields{
+			"module": "storage",
+			"func":   "StreamChannelMake",
+			"call":   "mergo.Merge",
+		}).Errorln(err.Error())
+	}
 	//make client's
-	val.clients = make(map[string]ClientST)
+	channel.clients = make(map[string]ClientST)
 	//make last ack
-	val.ack = time.Now().Add(-255 * time.Hour)
+	channel.ack = time.Now().Add(-255 * time.Hour)
 	//make hls buffer
-	val.hlsSegmentBuffer = make(map[int]SegmentOld)
+	channel.hlsSegmentBuffer = make(map[int]SegmentOld)
 	//make signals buffer chain
-	val.signals = make(chan int, 100)
-	return val
+	channel.signals = make(chan int, 100)
+	return channel
 }
 
 //StreamChannelRunAll run all stream go

--- a/storageStruct.go
+++ b/storageStruct.go
@@ -44,9 +44,10 @@ var (
 
 //StorageST main storage struct
 type StorageST struct {
-	mutex   sync.RWMutex
-	Server  ServerST            `json:"server" groups:"api,config"`
-	Streams map[string]StreamST `json:"streams,omitempty" groups:"api,config"`
+	mutex           sync.RWMutex
+	Server          ServerST            `json:"server" groups:"api,config"`
+	Streams         map[string]StreamST `json:"streams,omitempty" groups:"api,config"`
+	ChannelDefaults ChannelST           `json:"channel_defaults,omitempty" groups:"api,config"`
 }
 
 //ServerST server storage section


### PR DESCRIPTION
Add a channel_defaults configuration option which is merged with the channel configuration to allow global configuration options like insecure_skip_verify to be specified at startup time, though is flexible to support other options too in the future.

Issue #82