### PR TITLE
Preserve token config keys on save

### DIFF
--- a/storageStruct.go
+++ b/storageStruct.go
@@ -71,8 +71,8 @@ type ServerST struct {
 
 //Token auth
 type Token struct {
-	Enable  bool   `json:"enable,omitempty" groups:"api,config"`
-	Backend string `json:"backend,omitempty" groups:"api,config"`
+	Enable  bool   `json:"enable" groups:"api,config"`
+	Backend string `json:"backend" groups:"api,config"`
 }
 
 //ServerST stream storage section


### PR DESCRIPTION
When adding or updating a stream from the UI, `server.token.enabled` gets removed from the config if `false`.

The new config.json compared to the provided (default) one after save with this change:
```diff
--- config.json
+++ config.json
@@ -7,24 +7,24 @@
     "http_login": "demo",
     "http_password": "demo",
     "http_port": ":8083",
-    "log_level": "debug",
-    "rtsp_port": ":5541",
     "https": false,
-    "https_port": ":443",
+    "https_auto_tls": false,
+    "https_auto_tls_name": "",
     "https_cert": "server.crt",
     "https_key": "server.key",
+    "https_port": ":443",
+    "log_level": "debug",
+    "rtsp_port": ":5541",
     "token": {
-      "enable": false,
-      "backend": "http://127.0.0.1/test.php"
+      "backend": "http://127.0.0.1/test.php",
+      "enable": false
     }
-},
+  },
   "streams": {
     "demo": {
       "channels": {
         "0": {
           "debug": true,
-          "on_demand": false,
-          "insecure_skip_verify": true,
           "url": "rtsp://admin:deep18rwip@176.117.205.3:5541/video1"
         }
       },
```