### PR TITLE
Update configuration path in docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,11 +16,14 @@ FROM alpine:3.15
 
 WORKDIR /app
 
+
 COPY --from=builder /go/src/app/rtsp-to-web /app/
 COPY --from=builder /go/src/app/web /app/web
-COPY --from=builder /go/src/app/config.json /app/
+
+RUN mkdir -p /config
+COPY --from=builder /go/src/app/config.json /config
 
 ENV GO111MODULE="on"
 ENV GIN_MODE="release"
 
-CMD ["./rtsp-to-web"]
+CMD ["./rtsp-to-web", "--config=/config/config.json"]

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ You may override the <a href="#example-configjson">configuration</a> `/PATH_TO_C
 
 ```bash
 $ docker run --name rtsp-to-web \
-    -v /PATH_TO_CONFIG/config.json:/app/config.json \
+    -v /PATH_TO_CONFIG/config.json:/config/config.json \
     --network host \
     ghcr.io/deepch/rtsptoweb:latest 
 ```


### PR DESCRIPTION
Update the configuration path in the docker file to /config which is a
fairly standard location for mounting config files. This will make it
easier to play nicely with default helm charts, for example.