### PR TITLE
Crash fix: Guard against null hlsMuxer

### DIFF
--- a/storageStreamChannel.go
+++ b/storageStreamChannel.go
@@ -362,7 +362,7 @@ func (obj *StorageST) HlsMuxerWritePacket(uuid string, channelID string, packet 
 	obj.mutex.RLock()
 	defer obj.mutex.RUnlock()
 	if tmp, ok := obj.Streams[uuid]; ok {
-		if channelTmp, ok := tmp.Channels[channelID]; ok {
+		if channelTmp, ok := tmp.Channels[channelID]; ok && channelTmp.hlsMuxer != nil {
 			channelTmp.hlsMuxer.WritePacket(packet)
 		}
 	}


### PR DESCRIPTION
Add a check for nil hlsMixer similar to the fix in commit 7beb35a06363f9453ae71361d4dedecafbefdfa4

```
[14:51:47] INFO: Successfully send discovery information to Home Assistant (8083).
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xb94673]
goroutine 101 [running]:
main.(*MuxerHLS).WritePacket(0x0, 0xc0011c9780)
	/workspace/hlsMuxer.go:48 +0x33
main.(*StorageST).HlsMuxerWritePacket(0xc0000320f0, 0xc000038f3d, 0xd, 0x12af380, 0x1, 0xc0011c9780)
	/workspace/storageStreamChannel.go:366 +0x1f9
main.StreamServerRunStream(0xc000038f3d, 0xd, 0x12af380, 0x1, 0xc0000e0370, 0x0, 0x0, 0x0)
	/workspace/streamCore.go:173 +0xb09
main.StreamServerRunStreamDo(0xc000038f3d, 0xd, 0x12af380, 0x1)
	/workspace/streamCore.go:43 +0x4fa
created by main.(*StorageST).StreamEdit
	/workspace/storageStream.go:65 +0x5ff
[cont-finish.d] executing container finish scripts...
```

Issue #89