### PR TITLE
Multi-platform docker image build

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -19,6 +19,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1.2.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1.6.0
+
       - name: Docker Login
         uses: docker/login-action@v1.13.0
         with:
@@ -36,6 +42,7 @@ jobs:
         uses: docker/build-push-action@v2.9.0
         with:
           context: .
+          platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,22 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.18rc1-alpine3.15 AS builder
+FROM --platform=${BUILDPLATFORM} golang:1.18rc1-alpine3.15 AS builder
 
 RUN apk add git
 
 WORKDIR /go/src/app
 COPY . .
 
+ARG TARGETOS TARGETARCH TARGETVARIANT
+
 ENV CGO_ENABLED=0
 RUN go get \
     && go mod download \
-    && go build -a -o rtsp-to-web
+    && GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=${TARGETVARIANT#"v"} go build -a -o rtsp-to-web
 
 FROM alpine:3.15
 
 WORKDIR /app
-
 
 COPY --from=builder /go/src/app/rtsp-to-web /app/
 COPY --from=builder /go/src/app/web /app/web


### PR DESCRIPTION
Hi!
Currently the Docker image only supports linux/amd64 arch. 

This pull request adds multi-platform support for the platforms that Home Assistant currently supports:
- linux/386
- linux/amd64
- linux/arm/v6
- linux/arm/v7
- linux/arm64/v8

Tested generating an image on a separate github repo and running it on my RPI4. Validated that the image runs well now, but I have not tested the RTSPtoWeb functionality itself.