### PR TITLE
Update renovate to automatically merge minor versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,15 @@
 {
   "extends": [
     "config:base"
+  ],
+  "dependencyDashboard": true,
+  "dependencyDashboardTitle": "Renovate Dashboard",
+  "packageRules": [
+    {
+      "description": "Minor updates are automatic",
+      "automerge": true,
+      "automergeType": "branch",
+      "matchUpdateTypes": ["minor", "patch"]
+    }
   ]
 }


### PR DESCRIPTION
Update renovate to automatically merge minor versions and enable the renovate package dashboard (github issue) to view status of all pending packages.