### PR TITLE
Fix race in `StreamsList()`

### DIFF
--- a/apiHTTPStream.go
+++ b/apiHTTPStream.go
@@ -7,7 +7,12 @@ import (
 
 //HTTPAPIServerStreams function return stream list
 func HTTPAPIServerStreams(c *gin.Context) {
-	c.IndentedJSON(200, Message{Status: 1, Payload: Storage.StreamsList()})
+	list, err := Storage.MarshalledStreamsList()
+	if err != nil {
+		c.IndentedJSON(500, Message{Status: 0, Payload: err.Error()})
+		return
+	}
+	c.IndentedJSON(200, Message{Status: 1, Payload: list})
 }
 
 //HTTPAPIServerStreamsMultiControlAdd function add new stream's

--- a/storageStream.go
+++ b/storageStream.go
@@ -1,14 +1,18 @@
 package main
 
-//StreamsList list all stream
-func (obj *StorageST) StreamsList() map[string]StreamST {
+import "github.com/liip/sheriff"
+
+//MarshalledStreamsList lists all streams and includes only fields which are safe to serialize.
+func (obj *StorageST) MarshalledStreamsList() (interface{}, error) {
 	obj.mutex.RLock()
 	defer obj.mutex.RUnlock()
-	tmp := make(map[string]StreamST)
-	for i, i2 := range obj.Streams {
-		tmp[i] = i2
+	val, err := sheriff.Marshal(&sheriff.Options{
+		Groups: []string{"api"},
+	}, obj.Streams)
+	if err != nil {
+		return nil, err
 	}
-	return tmp
+	return val, nil
 }
 
 //StreamAdd add stream


### PR DESCRIPTION
This resolves issue number 1 of #294. For completeness:

> This method correctly locks `StorageST.mutex` _and_ performs a copy of `StorageST.Streams`, but the copy is not enough since it's just a shallow copy, so the `ChannelST` map pointer stays the same and can lead to crashes when other parts of the program attempt to write to the channels map.
> This can easily reproduced by invoking any API method that calls `Storage.StreamChannelExist`, since it mutates the map by changing the value of the `ack` field.
> The fix is to either copy `ChannelST` as well or marshal it beforehand (which removes the mutable fields). I intend to fix this soon in a PR.

To reproduce (substitute `<stream>` and `<channel>` with the appropriate IDs):

```sh
for i in {1..10}; do ( curl -s http://localhost:8083/stream{s,/<stream>/channel/<channel>/codec}; ) & done
```