### PR TITLE
Add unauthorized error to logging information

### DIFF
--- a/apiHTTPHLS.go
+++ b/apiHTTPHLS.go
@@ -29,7 +29,7 @@ func HTTPAPIServerStreamHLSM3U8(c *gin.Context) {
 	if !RemoteAuthorization("HLS", c.Param("uuid"), c.Param("channel"), c.Param("token"), c.ClientIP()) {
 		requestLogger.WithFields(logrus.Fields{
 			"call": "RemoteAuthorization",
-		}).Errorln(ErrorStreamNotFound.Error())
+		}).Errorln(ErrorStreamUnauthorized.Error())
 		return
 	}
 

--- a/apiHTTPHLSLL.go
+++ b/apiHTTPHLSLL.go
@@ -27,7 +27,7 @@ func HTTPAPIServerStreamHLSLLInit(c *gin.Context) {
 	if !RemoteAuthorization("HLS", c.Param("uuid"), c.Param("channel"), c.Param("token"), c.ClientIP()) {
 		requestLogger.WithFields(logrus.Fields{
 			"call": "RemoteAuthorization",
-		}).Errorln(ErrorStreamNotFound.Error())
+		}).Errorln(ErrorStreamUnauthorized.Error())
 		return
 	}
 

--- a/apiHTTPMSE.go
+++ b/apiHTTPMSE.go
@@ -44,7 +44,7 @@ func HTTPAPIServerStreamMSE(c *gin.Context) {
 	if !RemoteAuthorization("WS", c.Param("uuid"), c.Param("channel"), c.Param("token"), c.ClientIP()) {
 		requestLogger.WithFields(logrus.Fields{
 			"call": "RemoteAuthorization",
-		}).Errorln(ErrorStreamNotFound.Error())
+		}).Errorln(ErrorStreamUnauthorized.Error())
 		return
 	}
 

--- a/apiHTTPWebRTC.go
+++ b/apiHTTPWebRTC.go
@@ -28,10 +28,10 @@ func HTTPAPIServerStreamWebRTC(c *gin.Context) {
 	if !RemoteAuthorization("WebRTC", c.Param("uuid"), c.Param("channel"), c.Query("token"), c.ClientIP()) {
 		requestLogger.WithFields(logrus.Fields{
 			"call": "RemoteAuthorization",
-		}).Errorln(ErrorStreamNotFound.Error())
+		}).Errorln(ErrorStreamUnauthorized.Error())
 		return
 	}
-	
+
 	Storage.StreamChannelRun(c.Param("uuid"), c.Param("channel"))
 	codecs, err := Storage.StreamChannelCodecs(c.Param("uuid"), c.Param("channel"))
 	if err != nil {

--- a/serverRTSP.go
+++ b/serverRTSP.go
@@ -279,7 +279,7 @@ func RTSPServerClientHandle(conn net.Conn) {
 					"channel": channel,
 					"func":    "handleRTSPServerRequest",
 					"call":    "StreamChannelExist",
-				}).Errorln(ErrorStreamNotFound.Error())
+				}).Errorln(ErrorStreamUnauthorized.Error())
 				err = RTSPServerClientResponse(uuid, channel, conn, 401, map[string]string{"CSeq": strconv.Itoa(cSEQ)})
 				if err != nil {
 					return

--- a/storageStruct.go
+++ b/storageStruct.go
@@ -40,6 +40,7 @@ var (
 	ErrorStreamChannelNotFound      = errors.New("stream channel not found")
 	ErrorStreamChannelCodecNotFound = errors.New("stream channel codec not ready, possible stream offline")
 	ErrorStreamsLen0                = errors.New("streams len zero")
+	ErrorStreamUnauthorized         = errors.New("stream request unauthorized")
 )
 
 //StorageST main storage struct


### PR DESCRIPTION
I saw an area of improvement for the logs. currently we show a NotFound error when the user is unauthorized to view the stream. I thought it would be useful to include the appropriate error here.