### PR TITLE
tokens were not sent in hls, mse and hlsll bug fixed, it is taken as …

### DIFF
--- a/apiHTTPHLS.go
+++ b/apiHTTPHLS.go
@@ -26,7 +26,7 @@ func HTTPAPIServerStreamHLSM3U8(c *gin.Context) {
 		return
 	}
 
-	if !RemoteAuthorization("HLS", c.Param("uuid"), c.Param("channel"), c.Param("token"), c.ClientIP()) {
+	if !RemoteAuthorization("HLS", c.Param("uuid"), c.Param("channel"), c.Query("token"), c.ClientIP()) {
 		requestLogger.WithFields(logrus.Fields{
 			"call": "RemoteAuthorization",
 		}).Errorln(ErrorStreamUnauthorized.Error())

--- a/apiHTTPHLSLL.go
+++ b/apiHTTPHLSLL.go
@@ -24,7 +24,7 @@ func HTTPAPIServerStreamHLSLLInit(c *gin.Context) {
 		return
 	}
 
-	if !RemoteAuthorization("HLS", c.Param("uuid"), c.Param("channel"), c.Param("token"), c.ClientIP()) {
+	if !RemoteAuthorization("HLS", c.Param("uuid"), c.Param("channel"), c.Query("token"), c.ClientIP()) {
 		requestLogger.WithFields(logrus.Fields{
 			"call": "RemoteAuthorization",
 		}).Errorln(ErrorStreamUnauthorized.Error())

--- a/apiHTTPMSE.go
+++ b/apiHTTPMSE.go
@@ -41,7 +41,7 @@ func HTTPAPIServerStreamMSE(c *gin.Context) {
 		return
 	}
 
-	if !RemoteAuthorization("WS", c.Param("uuid"), c.Param("channel"), c.Param("token"), c.ClientIP()) {
+	if !RemoteAuthorization("WS", c.Param("uuid"), c.Param("channel"), c.Query("token"), c.ClientIP()) {
 		requestLogger.WithFields(logrus.Fields{
 			"call": "RemoteAuthorization",
 		}).Errorln(ErrorStreamUnauthorized.Error())


### PR DESCRIPTION
…query instead of param
It was resolved for WebRTC, but these were forgotten