### PR TITLE
Add unauthorized error to video endpoints

### DIFF
--- a/apiHTTPHLS.go
+++ b/apiHTTPHLS.go
@@ -27,6 +27,7 @@ func HTTPAPIServerStreamHLSM3U8(c *gin.Context) {
 	}
 
 	if !RemoteAuthorization("HLS", c.Param("uuid"), c.Param("channel"), c.Query("token"), c.ClientIP()) {
+		c.IndentedJSON(500, Message{Status: 0, Payload: ErrorStreamUnauthorized.Error()})
 		requestLogger.WithFields(logrus.Fields{
 			"call": "RemoteAuthorization",
 		}).Errorln(ErrorStreamUnauthorized.Error())

--- a/apiHTTPHLSLL.go
+++ b/apiHTTPHLSLL.go
@@ -25,6 +25,7 @@ func HTTPAPIServerStreamHLSLLInit(c *gin.Context) {
 	}
 
 	if !RemoteAuthorization("HLS", c.Param("uuid"), c.Param("channel"), c.Query("token"), c.ClientIP()) {
+		c.IndentedJSON(500, Message{Status: 0, Payload: ErrorStreamUnauthorized.Error()})
 		requestLogger.WithFields(logrus.Fields{
 			"call": "RemoteAuthorization",
 		}).Errorln(ErrorStreamUnauthorized.Error())

--- a/apiHTTPMSE.go
+++ b/apiHTTPMSE.go
@@ -42,6 +42,7 @@ func HTTPAPIServerStreamMSE(c *gin.Context) {
 	}
 
 	if !RemoteAuthorization("WS", c.Param("uuid"), c.Param("channel"), c.Query("token"), c.ClientIP()) {
+		c.IndentedJSON(500, Message{Status: 0, Payload: ErrorStreamUnauthorized.Error()})
 		requestLogger.WithFields(logrus.Fields{
 			"call": "RemoteAuthorization",
 		}).Errorln(ErrorStreamUnauthorized.Error())

--- a/apiHTTPSaveMP4.go
+++ b/apiHTTPSaveMP4.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"time"
+
 	"github.com/deepch/vdk/format/mp4"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
-	"os"
-	"time"
 )
 
 // HTTPAPIServerStreamSaveToMP4 func
@@ -36,6 +37,7 @@ func HTTPAPIServerStreamSaveToMP4(c *gin.Context) {
 	}
 
 	if !RemoteAuthorization("save", c.Param("uuid"), c.Param("channel"), c.Query("token"), c.ClientIP()) {
+		c.IndentedJSON(500, Message{Status: 0, Payload: ErrorStreamUnauthorized.Error()})
 		requestLogger.WithFields(logrus.Fields{
 			"call": "RemoteAuthorization",
 		}).Errorln(ErrorStreamUnauthorized.Error())

--- a/apiHTTPWebRTC.go
+++ b/apiHTTPWebRTC.go
@@ -26,6 +26,7 @@ func HTTPAPIServerStreamWebRTC(c *gin.Context) {
 	}
 
 	if !RemoteAuthorization("WebRTC", c.Param("uuid"), c.Param("channel"), c.Query("token"), c.ClientIP()) {
+		c.IndentedJSON(500, Message{Status: 0, Payload: ErrorStreamUnauthorized.Error()})
 		requestLogger.WithFields(logrus.Fields{
 			"call": "RemoteAuthorization",
 		}).Errorln(ErrorStreamUnauthorized.Error())


### PR DESCRIPTION
Currently, if you enable authentication and you request a resource from one of the video endpoints, you get an empty response  with a 200 status. with this change, clients can be made aware if a request to a resource was not approved by your token backend.