### PR TITLE
when a stream had no channel, but it had a name, we couldn't add a ne…

### DIFF
--- a/storageStreamChannel.go
+++ b/storageStreamChannel.go
@@ -260,11 +260,16 @@ func (obj *StorageST) StreamChannelAdd(uuid string, channelID string, val Channe
 	if _, ok := obj.Streams[uuid]; !ok {
 		return ErrorStreamNotFound
 	}
+	stream := obj.Streams[uuid]
+	if stream.Channels == nil {
+		stream.Channels = make(map[string]ChannelST)
+	}
 	if _, ok := obj.Streams[uuid].Channels[channelID]; ok {
 		return ErrorStreamChannelAlreadyExists
 	}
 	val = obj.StreamChannelMake(val)
-	obj.Streams[uuid].Channels[channelID] = val
+	stream.Channels[channelID] = val
+	obj.Streams[uuid] = stream
 	if !val.OnDemand {
 		val.runLock = true
 		go StreamServerRunStreamDo(uuid, channelID)


### PR DESCRIPTION
…w channel - bug fix

for example: my config.json is like this

```
.
.
.
"streams": {
    "20274": {
      "name": "20274"
    },
    "20275": {
      "name": "20275"
    },
    "49": {
      "name": "49"
    }
  }
```
When I try to add a channel to 49, I wasn't able to, because I was getting: `time="2023-12-25T17:56:47+03:00" level=error msg="stream not found" call=StreamChannelExist channel=main func=HTTPAPIServerStreamHLSM3U8 module=http_hls stream=20275`
And you could easily reproduce, remove channels from a stream and this error will occur.