### PR TITLE
feat: add favicon

### DIFF
--- a/web/static/img/lens.svg
+++ b/web/static/img/lens.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg height="800px" width="800px" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 464 464" xml:space="preserve">
+<circle style="fill:#464655;" cx="232" cy="232" r="197"/>
+<path style="fill:#707487;" d="M232,0C103.87,0,0,103.87,0,232s103.87,232,232,232s232-103.87,232-232S360.13,0,232,0z M232,424
+	c-106.039,0-192-85.962-192-192c0-106.039,85.961-192,192-192s192,85.961,192,192C424,338.038,338.039,424,232,424z"/>
+<circle style="fill:#5B5D6E;" cx="232" cy="232" r="144"/>
+<path style="fill:#464655;" d="M232,352c-66.172,0-120-53.828-120-120s53.828-120,120-120s120,53.828,120,120S298.172,352,232,352z
+	 M232,128c-57.344,0-104,46.656-104,104s46.656,104,104,104s104-46.656,104-104S289.344,128,232,128z"/>
+<circle style="fill:#D7DEED;" cx="232" cy="232" r="104"/>
+<circle style="fill:#C7CFE2;" cx="232" cy="232" r="88"/>
+<circle style="fill:#959CB3;" cx="232" cy="232" r="72"/>
+<circle style="fill:#AFB9D2;" cx="232" cy="232" r="56"/>
+<circle style="fill:#82889D;" cx="232" cy="232" r="40"/>
+<g>
+	<circle style="fill:#FFFFFF;" cx="244" cy="220" r="12"/>
+	<circle style="fill:#FFFFFF;" cx="280" cy="184" r="20"/>
+</g>
+<circle style="fill:#D7DEED;" cx="184" cy="280" r="16"/>
+</svg>

--- a/web/templates/fullscreenmulti.tmpl
+++ b/web/templates/fullscreenmulti.tmpl
@@ -7,6 +7,7 @@
   <meta http-equiv="x-ua-compatible" content="ie=edge">
 
   <title>RTSPtoWEB</title>
+  <link rel="icon" href="/../static/img/lens.svg">
   <link rel="stylesheet" href="/../static/plugins/fontawesome-free/css/all.min.css">
   <link rel="stylesheet" href="/../static/css/adminlte.min.css">
   <link rel="stylesheet" href="/../static/plugins/sweetalert2/sweetalert2.min.css">

--- a/web/templates/head.tmpl
+++ b/web/templates/head.tmpl
@@ -7,6 +7,7 @@
   <meta http-equiv="x-ua-compatible" content="ie=edge">
 
   <title>RTSPtoWEB</title>
+  <link rel="icon" href="/../static/img/lens.svg">
   <link rel="stylesheet" href="/../static/plugins/fontawesome-free/css/all.min.css">
   <link rel="stylesheet" href="/../static/css/adminlte.min.css">
   <link rel="stylesheet" href="/../static/plugins/sweetalert2/sweetalert2.min.css">


### PR DESCRIPTION
The example app works fine as an application to monitor some cameras, but it has no favicon which makes it not that nice on the browser tab. This PR adds a free lens icon to the main page and the fullscreen page. This is the result:

![image](https://github.com/user-attachments/assets/c4d24f66-0902-4e61-b87b-46613f495d93)

SVG source: https://www.svgrepo.com/svg/79115/lens