### PR TITLE
feat: manually specify ice candidates

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,20 +61,21 @@ $ docker run --name rtsp-to-web \
 ### Server settings
 
 ```text
-debug           - enable debug output
-log_level       - log level (trace, debug, info, warning, error, fatal, or panic)
+debug              - enable debug output
+log_level          - log level (trace, debug, info, warning, error, fatal, or panic)
 
-http_demo       - serve static files
-http_debug      - debug http api server
-http_login      - http auth login
-http_password   - http auth password
-http_port       - http server port
-http_dir        - path to serve static files from
-ice_servers     - array of servers to use for STUN/TURN
-ice_username    - username to use for STUN/TURN
-ice_credential  - credential to use for STUN/TURN
-webrtc_port_min - minimum WebRTC port to use (UDP)
-webrtc_port_max - maximum WebRTC port to use (UDP)
+http_demo          - serve static files
+http_debug         - debug http api server
+http_login         - http auth login
+http_password      - http auth password
+http_port          - http server port
+http_dir           - path to serve static files from
+ice_servers        - array of servers to use for STUN/TURN
+ice_username       - username to use for STUN/TURN
+ice_credential     - credential to use for STUN/TURN
+ice_candidates     - manually set ice candidates
+webrtc_port_min    - minimum WebRTC port to use (UDP)
+webrtc_port_max    - maximum WebRTC port to use (UDP)
 
 https
 https_auto_tls

--- a/apiHTTPWebRTC.go
+++ b/apiHTTPWebRTC.go
@@ -41,7 +41,22 @@ func HTTPAPIServerStreamWebRTC(c *gin.Context) {
 		}).Errorln(err.Error())
 		return
 	}
-	muxerWebRTC := webrtc.NewMuxer(webrtc.Options{ICEServers: Storage.ServerICEServers(), ICEUsername: Storage.ServerICEUsername(), ICECredential: Storage.ServerICECredential(), PortMin: Storage.ServerWebRTCPortMin(), PortMax: Storage.ServerWebRTCPortMax()})
+
+	options := webrtc.Options{
+	    ICEServers:    Storage.ServerICEServers(),
+	    ICEUsername:   Storage.ServerICEUsername(),
+	    ICECredential: Storage.ServerICECredential(),
+	    PortMin:       Storage.ServerWebRTCPortMin(),
+	    PortMax:       Storage.ServerWebRTCPortMax(),
+	}
+	
+	//Ensures that ice_candidates is optional
+	if len(Storage.ServerICECandidates()) > 0 {
+	    options.ICECandidates = Storage.ServerICECandidates()
+	}
+
+	muxerWebRTC := webrtc.NewMuxer(options)
+
 	answer, err := muxerWebRTC.WriteHeader(codecs, c.PostForm("data"))
 	if err != nil {
 		c.IndentedJSON(400, Message{Status: 0, Payload: err.Error()})

--- a/storageServer.go
+++ b/storageServer.go
@@ -160,3 +160,11 @@ func (obj *StorageST) ServerWebRTCPortMax() uint16 {
 	defer obj.mutex.Unlock()
 	return obj.Server.WebRTCPortMax
 }
+
+// ServerIceCandidates returns the configured IceCandidates.
+func (obj *StorageST) ServerICECandidates() []string {
+    obj.mutex.Lock()
+    defer obj.mutex.Unlock()
+    return obj.Server.ICECandidates
+}
+

--- a/storageStruct.go
+++ b/storageStruct.go
@@ -71,6 +71,7 @@ type ServerST struct {
 	ICEServers         []string     `json:"ice_servers" groups:"api,config"`
 	ICEUsername        string       `json:"ice_username" groups:"api,config"`
 	ICECredential      string       `json:"ice_credential" groups:"api,config"`
+	ICECandidates      []string     `json:"ice_candidates" groups:"api,config"`
 	Token              Token        `json:"token,omitempty" groups:"api,config"`
 	WebRTCPortMin      uint16       `json:"webrtc_port_min" groups:"api,config"`
 	WebRTCPortMax      uint16       `json:"webrtc_port_max" groups:"api,config"`


### PR DESCRIPTION
## Problem
Current project is using a containerized environment, but specifying network=host is not always possible for some organizations.  

## Fix
I have enabled manually specifying ice candidates which allows for the use of a loadbalancer service or similar to get around the problem with container NAT networks.  
ice_candidates is an optional parameter in the config.json file specified by:

```go
if len(Storage.ServerICECandidates()) > 0 {
    options.ICECandidates = Storage.ServerICECandidates()
}
```

This is passed to vdk NewMuxer as it directly supports specifying ice candidates.