### PR TITLE
fix:remove redundant query params from WebRTC URL

### DIFF
--- a/web/templates/play_webrtc.tmpl
+++ b/web/templates/play_webrtc.tmpl
@@ -58,7 +58,7 @@
             case 'have-local-offer':
             let uuid = $('#uuid').val();
             let channel = $('#channel').val();
-            let url = "/stream/" + uuid + "/channel/" + channel + "/webrtc?uuid=" + uuid + '&channel=' + channel;
+            let url = "/stream/" + uuid + "/channel/" + channel + "/webrtc";
             $.post(url, {
               data: btoa(webrtc.localDescription.sdp)
             }, function(data) {


### PR DESCRIPTION
The original URL repeated uuid and channel in both the path and the query string. 
The backend route only uses the path variables; the query string is unused and only adds length and log noise.